### PR TITLE
fix: can't open file '/workspace/copy-image.py'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,4 @@ COPY --from=build-venv /venv /venv
 
 WORKDIR /app
 COPY copy-image.py /app/copy-image.py
-ENTRYPOINT ["/venv/bin/python3", "copy-image.py"]
+ENTRYPOINT ["/venv/bin/python3", "/app/copy-image.py"]


### PR DESCRIPTION
When the step is run by Cloud Build, the WORKDIR directive is ignored
because Cloud Build runs the step with `--workdir /workspace`. To work around
this, specify the path to the copy-image script fully.

Signed-off-by: Erik Swanson <erik@retailnext.net>